### PR TITLE
add optimization flag "-O3" for smlsharp

### DIFF
--- a/makefile-smlsharp
+++ b/makefile-smlsharp
@@ -7,7 +7,7 @@ else
 endif
 
 VPATH = .:smlnjlib
-SMLSHARPFLAGS = -I smlnjlib
+SMLSHARPFLAGS = -I smlnjlib -O3
 
 ## source code
 SRCS = random.sml \
@@ -47,4 +47,3 @@ clean:
 	rm -f $(filter %.d,$(SRCS:.sml=.d))
 	rm -f $(addprefix smlnjlib/,$(OBJS))
 	rm -f aobench.o
-


### PR DESCRIPTION
`makefile-smlsharp` lacks optimization flags. It slightly make the performance difference.

### experiments
My environment is just on virtual machine, so it is not so serious.
But my addition affects modest performance impact, I believe.

#### No optimization flags
```
[~/aobench_sml] time ./aobench-smlsharp
init_scene...
rendering...

real    0m10.412s
user    0m6.144s
sys     0m4.744s
```

#### Add `-O3`

```
time ./aobench-smlsharp
init_scene...
rendering...

real    0m8.354s
user    0m5.180s
sys     0m3.524s
```
